### PR TITLE
Faster Queues

### DIFF
--- a/cogs/music-commands.py
+++ b/cogs/music-commands.py
@@ -96,6 +96,8 @@ class Music(commands.Cog):
 
             # Step 1: get flat entry list fast (no stream URL resolution yet)
             flat_tracks = await asyncio.get_event_loop().run_in_executor(None, lambda: get_flat_entries(query))
+            for entry in flat_tracks:
+                queue.append((None, entry[1]))
 
             if len(flat_tracks) > 1:
                 msg = f"Adicionados {len(flat_tracks)} músicas à fila :D" if lang == "pt" else f"Added {len(flat_tracks)} songs to the queue!"
@@ -106,14 +108,17 @@ class Music(commands.Cog):
 
             # Step 2: resolve and enqueue in background
             async def resolve_and_enqueue():
-                for entry in flat_tracks:
+                for i, entry in enumerate(flat_tracks):
                     url, title = await asyncio.get_event_loop().run_in_executor(None, lambda e=entry: resolve_entry(e))
-                    queue.append((url, title))
+                    for j, (q_url, q_title) in enumerate(queue):
+                        if q_title == entry[1] and q_url is None:
+                            queue[j] = (url, title)
+                            break
 #                    TODO: FIX  THIS MESS
 #                    queue_looped = get_queue_looped(ctx.author.id
 #                    if ctx.guild.id in queue_looped:
 #                        queue_looped[ctx.guild.id].append((url, title))
-                    if not ctx.voice_client.is_playing():
+                    if i == 0 and not ctx.voice_client.is_playing():
                         await play_next(ctx)
             asyncio.create_task(resolve_and_enqueue())
 

--- a/music.py
+++ b/music.py
@@ -83,11 +83,17 @@ async def play_next(ctx):
         else:
             return
     if len(queue) > 0:
+        while queue and queue[0][0] is None:
+            await asyncio.sleep(0.5)
+        if not queue:
+            return
         current = queue[0][1]
         lang = get_user_lang(ctx.author.id)
         msg = f"Tocando Agora: {current}" if lang == "pt" else f"Now Playing: {current}"
         loop = asyncio.get_event_loop()
         url, title = queue.pop(0)
+        if url is None:
+            return
         ctx.voice_client.play(
             discord.FFmpegPCMAudio(url, **FFMPEG_OPTIONS),
             after=lambda e: asyncio.run_coroutine_threadsafe(play_next(ctx), loop)


### PR DESCRIPTION
With these changes, the bot now can add all songs to the queue instantly, while silently downloading them in the background.

The main issue, however, is that now if you use the shuffle command, and it randomly chooses a song that haven't yet been downloaded, it stops playing and crashes. The "fix" is to wait for all the songs to finish downloading. However, there's no confirmation of when that happens, so you need to guess...

I'll try to fix this later